### PR TITLE
Using serverless-webpack 2.2.0 lib extension.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "rc": "^1.1.6",
     "serverless": "^1.17.0",
     "serverless-offline": "^3.15.1",
-    "serverless-webpack": "2.0.0",
+    "serverless-webpack": "^2.2.0",
     "shebang-loader": "0.0.1",
     "strip-debug-loader": "^1.0.0",
     "webpack": "^3.3.0"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,17 +1,9 @@
 const path = require('path');
 const webpack = require('webpack');
+const slsw = require('serverless-webpack')
 
 const config = {
-  entry: {
-    config: './src/Config/api.js',
-    forms: './src/Forms/api.js',
-    hello: './src/Hello/api.js',
-    interop: './src/Interop/api.js',
-    pipelines: './src/Pipelines/api.js',
-    quoted: './src/Quoted/api.js',
-    routing: './src/Routing/api.js',
-    sideEffects: './src/SideEffects/api.js',
-  },
+  entry: slsw.lib.entries,
   target: 'node', // Ignores built-in modules like path, fs, etc.
 
   output: {


### PR DESCRIPTION
By bumping the `serverless-webpack` dependency to 2.2.0, the setup doesn't work anymore. @HyperBrain suggested in elastic-coders/serverless-webpack#174 to use the `entry: slsw.lib.entries` in the webpack config. This branch contains such a setup for further investigation. *Do not merge for now.*

Once a solution is found, I shall add it to this branch so it can be merged to help any others bumping into the same issue.