### PR TITLE
Use Serverless-webpack V3 RC.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "rc": "^1.1.6",
     "serverless": "^1.17.0",
     "serverless-offline": "^3.15.1",
-    "serverless-webpack": "2.0.0",
+    "serverless-webpack": "^3.0.0-rc.1",
     "shebang-loader": "0.0.1",
     "strip-debug-loader": "^1.0.0",
     "webpack": "^3.3.0"

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,7 +15,7 @@ custom:
 
 functions:
   hello:
-    handler: hello.handler # Refers to function `handler` exported from `Hello/api.js`
+    handler: src/Hello/api.handler # Refers to function `handler` exported from `Hello/api.js`
     events:
       - http:
           integration: lambda-proxy
@@ -23,7 +23,7 @@ functions:
           method: ANY
 
   config:
-    handler: config.handler
+    handler: src/Config/api.handler
     events:
       - http:
           integration: lambda-proxy
@@ -31,7 +31,7 @@ functions:
           method: ANY
 
   forms:
-    handler: forms.handler
+    handler: src/Forms/api.handler
     events:
       - http:
           integration: lambda-proxy
@@ -39,7 +39,7 @@ functions:
           method: ANY
 
   interop:
-    handler: interop.handler
+    handler: src/Interop/api.handler
     events:
       - http:
           integration: lambda-proxy
@@ -51,7 +51,7 @@ functions:
           method: ANY
 
   routing:
-    handler: routing.handler
+    handler: src/Routing/api.handler
     events:
       - http:
           integration: lambda-proxy
@@ -63,7 +63,7 @@ functions:
           method: ANY
 
   pipelines:
-    handler: pipelines.handler
+    handler: src/Pipelines/api.handler
     events:
       - http:
           integration: lambda-proxy
@@ -71,7 +71,7 @@ functions:
           method: ANY
 
   sideEffects:
-    handler: sideEffects.handler
+    handler: src/SideEffects/api.handler
     events:
       - http:
           integration: lambda-proxy
@@ -83,7 +83,7 @@ functions:
           method: ANY
 
   quoted:
-    handler: quoted.handler
+    handler: src/Quoted/api.handler
     events:
       - http:
           integration: lambda-proxy

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,17 +1,9 @@
 const path = require('path');
 const webpack = require('webpack');
+const slsw = require('serverless-webpack');
 
 const config = {
-  entry: {
-    config: './src/Config/api.js',
-    forms: './src/Forms/api.js',
-    hello: './src/Hello/api.js',
-    interop: './src/Interop/api.js',
-    pipelines: './src/Pipelines/api.js',
-    quoted: './src/Quoted/api.js',
-    routing: './src/Routing/api.js',
-    sideEffects: './src/SideEffects/api.js',
-  },
+  entry: slsw.lib.entries,
   target: 'node', // Ignores built-in modules like path, fs, etc.
 
   output: {
@@ -21,23 +13,33 @@ const config = {
   },
 
   module: {
-    loaders: [{
-      // Compiles elm to JavaScript.
-      test: /\.elm$/,
-      exclude: [/elm-stuff/, /node_modules/],
-      loader: 'elm-webpack-loader',
-    }],
+    rules: [
+      {
+        // Compiles elm to JavaScript.
+        test: /\.elm$/,
+        exclude: [/elm-stuff/, /node_modules/],
+        use: [
+          {
+            loader: 'elm-webpack-loader'
+          }
+        ]
+      }
+    ]
   },
 };
 
 if (process.env.NODE_ENV === 'production') {
   // Bridge is written for node 6.10. While AWS Lambda supports it
   // the UglifyJsPlugin does not :( so until that happens we use babel.
-  config.module.loaders.push({
+  config.module.rules.push({
     test: /\.js$/,
     exclude: [/elm-stuff/, /node_modules/],
-    loader: 'babel-loader',
-    options: { presets: 'env' },
+    use: [
+      {
+        loader: 'babel-loader',
+        options: { presets: 'env' }
+      }
+    ]
   });
 
   config.plugins = config.plugins || [];


### PR DESCRIPTION
@ktonon @ringods Can you check with my changes in this PR. It should be configured correctly now and works for me.
This PR now uses `serverless-webpack@^3.0.0-rc.1` but with the same configuration it should also work with `^2.2.0`

The fix was to reference the handlers correctly in `serverless.yml` and use `module:rules` in webpack.,config as this is the format used since webpack 2