### PR TITLE
Correct fix to get a working demo setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "eslint": "^3.13.1",
     "eslint-config-es2015": "^1.1.0",
     "rc": "^1.1.6",
-    "serverless": "^1.17.0",
-    "serverless-offline": "^3.15.1",
+    "serverless": "^1.19.0",
+    "serverless-offline": "^3.15.3",
     "serverless-webpack": "^3.0.0-rc.1",
     "shebang-loader": "0.0.1",
     "strip-debug-loader": "^1.0.0",
-    "webpack": "^3.3.0"
+    "webpack": "^3.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "rc": "^1.1.6",
     "serverless": "^1.19.0",
     "serverless-offline": "^3.15.3",
-    "serverless-webpack": "^3.0.0-rc.1",
+    "serverless-webpack": "^2.2.0",
     "shebang-loader": "0.0.1",
     "strip-debug-loader": "^1.0.0",
     "webpack": "^3.5.4"

--- a/serverless.yml
+++ b/serverless.yml
@@ -10,7 +10,6 @@ plugins:
 
 custom:
   serverless-offline:
-    location: .webpack/service
     dontPrintOutput: true
 
 functions:


### PR DESCRIPTION
Correct fix to get a working demo setup with latest dependency versions. The correct fix, [as suggested](https://github.com/ktonon/elm-serverless-demo/pull/2#issuecomment-322732416) by @HyperBrain was to remove the `location` setting from the `serverless-offline` plugin.

Also updated the dependencies to the latest versions. Verified correct functioning after bumping each of the dependencies.